### PR TITLE
Add test workflow to test the action on changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   test-action:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test the action locally
+
+on:
+  push:
+    paths-ignore:
+     - 'README.md'
+     - 'LICENSE'
+  pull_request:
+    branches:
+     - main
+  schedule:
+    # only run once a week to show the action is working and preserve as much energy as possible
+    - cron: '22 4 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3
+      
+      - name: Initialize Energy Estimation
+        uses: ./
+        with:
+          task: start-measurement
+    
+      - name: Wait before the next step
+        run: sleep 10
+
+      - name: Test measurement
+        uses: ./
+        with:
+          task: get-measurement
+          label: "Sleep"
+
+      - name: Eco CI Energy Estimation
+        uses: ./
+        with:
+          task: final-measurement


### PR DESCRIPTION
Closes #8 

To discuss: I've just included a simple run with a 10 second wait to have something to measure. We could add an extra job that skips the `sleep`, but it seemed like a waste of energy to not really proof anything (we know how long the sleep takes 😄).