### PR TITLE
remove doubled cache instruction

### DIFF
--- a/eco-ci-gitlab.yml
+++ b/eco-ci-gitlab.yml
@@ -8,10 +8,6 @@ variables:
   ECO_CI_DISPLAY_TABLE: "true" # true
   ECO_CI_DISPLAY_GRAPH: "false" # false
 
-cache:
-    paths:
-        - /tmp/eco-ci/venv/
-
 .initialize_energy_estimator:
     script:
         - |


### PR DESCRIPTION
yaml file parsers are marking the cache instruction as doubled - this commit removes the second ocurrance as it is an exact copy of the first one