### PR TITLE
fix: non-formatted details of old measurements

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -170,7 +170,7 @@ runs:
             COMMENT_ID=$(echo "$comment" | jq -r '.id')
             COMMENT_BODY=$(echo "$comment" | jq -r '.body')
             COMMENT_BODY=$(echo "$COMMENT_BODY" | sed 's/<details><summary>Old Energy Estimation<\/summary>//g' | sed 's/<\/details>//g')     
-            PAYLOAD=$(jq --null-input --arg body "<details><summary>Old Energy Estimation</summary>$COMMENT_BODY</details>" '{"body": $body}')
+            PAYLOAD=$(jq --null-input --arg body "<details><summary>Old Energy Estimation</summary>\n\n$COMMENT_BODY\n</details>" '{"body": $body}')
             curl -s -H "Authorization: Bearer ${{github.token}}" -X PATCH -d "$PAYLOAD" "https://${{inputs.api-base}}/repos/${{ github.repository }}/issues/comments/$COMMENT_ID"
             echo "Comment $COMMENT_ID collapsed."
         done


### PR DESCRIPTION
The `<detail>` view of old measurements is not formatted correctly. This is reproduced in this PR: https://github.com/jreimone/public-reproduction/pull/3